### PR TITLE
remove url listener on promise resolve

### DIFF
--- a/src/keycloak.js
+++ b/src/keycloak.js
@@ -1684,9 +1684,10 @@
                         var promise = createPromise();
                         var loginUrl = kc.createLoginUrl(options);
 
-                        window.Capacitor.Plugins.App.addListener('appUrlOpen', (data) => {
+                        const addUrlListener = window.Capacitor.Plugins.App.addListener('appUrlOpen', (data) => {
                             var oauth = parseCallback(data.url);
                             processCallback(oauth, promise);
+                            addUrlListener.remove();
                         });
 
                         window.open(loginUrl,'_system');
@@ -1697,9 +1698,10 @@
                         var promise = createPromise();
                         var logoutUrl = kc.createLogoutUrl(options);
 
-                        window.Capacitor.Plugins.App.addListener('appUrlOpen', (data) => {
+                        const addUrlListener = window.Capacitor.Plugins.App.addListener('appUrlOpen', (data) => {
                             kc.clearToken();
                             promise.setSuccess();
+                            addUrlListener.remove();
                         });
 
                         window.open(logoutUrl,'_system');


### PR DESCRIPTION
On each user login/logout there will be a new appUrlOpen Listener in the app.

This fix removes the listener on the resolve.